### PR TITLE
Check if the indexing of the item is canceled in the TransformingInde…

### DIFF
--- a/source/Novicell.Examine.ElasticSearch/Indexers/ElasticSearchBaseIndex.cs
+++ b/source/Novicell.Examine.ElasticSearch/Indexers/ElasticSearchBaseIndex.cs
@@ -252,24 +252,27 @@ namespace Novicell.Examine.ElasticSearch.Indexers
                 {
                     var indexingNodeDataArgs = new IndexingItemEventArgs(this, d);
                     OnTransformingIndexValues(indexingNodeDataArgs);
-                    //this is just a dictionary
-                    var ad = new Document
-                    {
-                        ["Id"] = d.Id,
-                        [FormatFieldName(LuceneIndex.ItemIdFieldName)] = d.Id,
-                        [FormatFieldName(LuceneIndex.ItemTypeFieldName)] = d.ItemType,
-                        [FormatFieldName(LuceneIndex.CategoryFieldName)] = d.Category
-                    };
+                    
+                    if (!indexingNodeDataArgs.Cancel) {
+                        //this is just a dictionary
+                        var ad = new Document
+                        {
+                            ["Id"] = d.Id,
+                            [FormatFieldName(LuceneIndex.ItemIdFieldName)] = d.Id,
+                            [FormatFieldName(LuceneIndex.ItemTypeFieldName)] = d.ItemType,
+                            [FormatFieldName(LuceneIndex.CategoryFieldName)] = d.Category
+                        };
 
-                    foreach (var i in d.Values)
-                    {
-                        if (i.Value.Count > 0)
-                            ad[FormatFieldName(i.Key)] = i.Value.Count == 1 ? i.Value[0] : i.Value;
+                        foreach (var i in d.Values)
+                        {
+                            if (i.Value.Count > 0)
+                                ad[FormatFieldName(i.Key)] = i.Value.Count == 1 ? i.Value[0] : i.Value;
+                        }
+
+                        var docArgs = new DocumentWritingEventArgs(d, ad);
+                        OnDocumentWriting(docArgs);
+                        descriptor.Index<Document>(op => op.Index(indexTarget).Document(ad).Id(d.Id));
                     }
-
-                    var docArgs = new DocumentWritingEventArgs(d, ad);
-                    OnDocumentWriting(docArgs);
-                    descriptor.Index<Document>(op => op.Index(indexTarget).Document(ad).Id(d.Id));
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
Sometimes you want to exclude items from beiing indexed by setting Cancel = true in the TransformingIndexValues event.
The if-statement skips the item from being indexed if it's canceled in this event.