### PR TITLE
fix: ensured that we escape dashes to ensured that query is correct

### DIFF
--- a/source/Novicell.Examine.ElasticSearch/ElasticSearchConfig.cs
+++ b/source/Novicell.Examine.ElasticSearch/ElasticSearchConfig.cs
@@ -16,6 +16,7 @@ namespace Novicell.Examine.ElasticSearch
 
         public static ConnectionSettings GetConnectionString(string indexName)
         {
+            
             if (ConnectionConfiguration.ContainsKey(indexName))
             {
                 return ConnectionConfiguration[indexName];
@@ -32,7 +33,7 @@ namespace Novicell.Examine.ElasticSearch
             if (ConfigurationManager.AppSettings.AllKeys.Any(s => s == "examine:ElasticSearch.Debug") &&
                 Convert.ToBoolean(ConfigurationManager.AppSettings["examine:ElasticSearch.Debug"]))
             {
-                return new ElasticSearchConfig("default", new ConnectionSettings());
+                return new ElasticSearchConfig(indexName.ToLower(), new ConnectionSettings());
             }
 
             return new ElasticSearchConfig(indexName.ToLower());

--- a/source/Novicell.Examine.ElasticSearch/ElasticSearchSearchResults.cs
+++ b/source/Novicell.Examine.ElasticSearch/ElasticSearchSearchResults.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Elasticsearch.Net;
 using Examine;
 using Examine.LuceneEngine.Providers;
@@ -152,7 +153,7 @@ namespace Novicell.Examine.ElasticSearch
                 }   
                 _queryContainer = new QueryContainer(new QueryStringQuery()
                 {
-                    Query = _luceneQuery.ToString(),
+                    Query = Regex.Replace(_luceneQuery.ToString(),@"([:,])-","$1\\-"),
                     AnalyzeWildcard = true
                     
                 });


### PR DESCRIPTION
This pr ensuring that looking by path will work. by escaping any dash prefixed value when in examine